### PR TITLE
implement registry type system with backward compatibility

### DIFF
--- a/cucumber-testing/features/02-backward-compatibility.feature
+++ b/cucumber-testing/features/02-backward-compatibility.feature
@@ -1,0 +1,63 @@
+Feature: Registry Type Backward Compatibility
+  As a developer upgrading RFH
+  I want existing registries without type field to continue working
+  So that I don't need to reconfigure my existing setup
+
+  Background:
+    Given RFH is installed and accessible
+    And I have a clean config file
+
+  Scenario: Load config with registries missing type field
+    Given a config file with content:
+      """
+      current = "legacy"
+      
+      [registries.legacy]
+      url = "https://legacy.example.com"
+      jwt_token = "token123"
+      """
+    When I run "rfh registry list"
+    Then I should see "legacy (remote-http)" in the registry list
+    And the command should exit with zero status
+    
+  Scenario: Existing registry operations work without type
+    Given a config file with content:
+      """
+      [registries.old]
+      url = "https://old.example.com"
+      """
+    When I run "rfh registry use old"
+    Then I should see "Set 'old' as active registry"
+    And "old" should be the current active registry
+    And the command should exit with zero status
+
+  Scenario: Mixed old and new registries work together
+    Given a config file with content:
+      """
+      current = "old"
+      
+      [registries.old]
+      url = "https://old.example.com"
+      
+      [registries.new]
+      url = "https://github.com/org/registry"
+      type = "git"
+      """
+    When I run "rfh registry list"
+    Then I should see "old (remote-http)" in the registry list
+    And I should see "new (git)" in the registry list
+    And I should see "old" marked as active
+
+  Scenario: Adding new registry to existing config preserves old ones
+    Given a config file with content:
+      """
+      [registries.legacy]
+      url = "https://legacy.example.com"
+      jwt_token = "oldtoken"
+      """
+    When I run "rfh registry add modern https://github.com/org/registry --type git"
+    Then I should see "Added registry 'modern'"
+    And the config should contain registry "legacy" with type "remote-http"
+    And the config should contain registry "modern" with type "git"
+    # Ensure JWT token is preserved
+    And the config should contain "jwt_token = 'oldtoken'"

--- a/cucumber-testing/features/02-registry-management.feature
+++ b/cucumber-testing/features/02-registry-management.feature
@@ -79,3 +79,41 @@ Feature: Registry Management
     When I run "rfh registry add production https://different.example.com"
     Then I should see "Added registry 'production'"
     And the config should contain registry "production" with URL "https://different.example.com"
+
+  Scenario: Add HTTP registry with explicit type
+    When I run "rfh registry add http-typed https://registry.example.com --type remote-http"
+    Then I should see "Added registry 'http-typed'"
+    And I should see "Type: remote-http"
+    And I should see "Use 'rfh auth login' to authenticate"
+    And the config should contain registry "http-typed" with type "remote-http"
+    
+  Scenario: Add Git registry
+    When I run "rfh registry add git-registry https://github.com/org/registry --type git"
+    Then I should see "Added registry 'git-registry'"
+    And I should see "Type: git"
+    And I should see "Set git_token in config or use GITHUB_TOKEN environment variable"
+    And the config should contain registry "git-registry" with type "git"
+    
+  Scenario: Add registry without type defaults to HTTP
+    When I run "rfh registry add default-registry https://registry.example.com"
+    Then I should see "Added registry 'default-registry'"
+    And I should see "Type: remote-http"
+    And the config should contain registry "default-registry" with type "remote-http"
+    
+  Scenario: Reject invalid registry type
+    When I run "rfh registry add invalid https://example.com --type invalid-type"
+    Then the command should exit with non-zero status
+    And I should see an error containing "unsupported registry type"
+    
+  Scenario: List shows registry types
+    Given I have a registry "typed-http" configured at "https://http.example.com" with type "remote-http"
+    And I have a registry "typed-git" configured at "https://github.com/org/repo" with type "git"
+    When I run "rfh registry list"
+    Then I should see "typed-http (remote-http)" in the registry list
+    And I should see "typed-git (git)" in the registry list
+
+  Scenario: Git registry URL validation warning
+    When I run "rfh registry add git-invalid https://example.com/not-git --type git"
+    Then I should see "Added registry 'git-invalid'"
+    And I should see "Warning: Git registry URL may not be valid"
+    And I should see "Type: git"

--- a/cucumber-testing/features/step_definitions/auth_steps.js
+++ b/cucumber-testing/features/step_definitions/auth_steps.js
@@ -149,11 +149,30 @@ Then('the command should exit with zero status', function () {
 });
 
 Given('I have a clean config file with no registries', async function () {
-  // Reset the config to a clean state using RFH commands
-  await this.resetConfig();
+  // Ensure the cucumber config directory exists 
+  await fs.ensureDir(this.testConfigDir);
   
   // Ensure configPath points to the shared test config location
   this.configPath = path.join(this.testConfigDir, 'config.toml');
+  
+  // Create a completely clean config file with no registries
+  const emptyConfig = `# Empty config for testing - no registries configured
+current = ""
+
+[registries]
+`;
+  await fs.writeFile(this.configPath, emptyConfig);
+  
+  // Reset internal state flags
+  this.registryConfigured = false;
+  this.currentUser = null;
+  this.rootJwtToken = null;
+  if (this.testUsers) {
+    this.testUsers.clear();
+  }
+  
+  // Small delay to ensure file is written
+  await new Promise(resolve => setTimeout(resolve, 100));
 });
 
 Given('I have a config with current registry {string}', async function (registryName) {

--- a/cucumber-testing/features/step_definitions/registry_steps.js
+++ b/cucumber-testing/features/step_definitions/registry_steps.js
@@ -97,6 +97,55 @@ Then('the config should contain registry {string} with URL {string}', async func
   expect(configContent, `Config should contain url = '${url}'\nActual config:\n${configContent}`).to.include(`url = '${url}'`);
 });
 
+// New step definitions for registry types
+Then('the config should contain registry {string} with type {string}', async function (registryName, registryType) {
+  await new Promise(resolve => setTimeout(resolve, 100));
+  
+  const configExists = await fs.pathExists(this.configPath);
+  expect(configExists, `Config file should exist at ${this.configPath}`).to.be.true;
+  
+  const configContent = await fs.readFile(this.configPath, 'utf8');
+  expect(configContent, `Config should contain [registries.${registryName}]\nActual config:\n${configContent}`).to.include(`[registries.${registryName}]`);
+  expect(configContent, `Config should contain type = '${registryType}'\nActual config:\n${configContent}`).to.include(`type = '${registryType}'`);
+});
+
+Given('I have a registry {string} configured at {string} with type {string}', async function (name, url, type) {
+  await this.runCommand(`rfh registry add ${name} ${url} --type ${type}`);
+  if (this.lastExitCode !== 0) {
+    throw new Error(`Failed to add registry ${name}: ${this.lastCommandError || this.lastCommandOutput}`);
+  }
+  
+  // Small delay to ensure file is written
+  await new Promise(resolve => setTimeout(resolve, 200));
+});
+
+Then('I should see an error containing {string}', function (expectedError) {
+  const output = this.lastCommandError || this.lastCommandOutput;
+  expect(output.toLowerCase()).to.include(expectedError.toLowerCase());
+});
+
+// Step definition for creating config files with specific content
+Given('a config file with content:', async function (docString) {
+  await fs.ensureDir(this.testConfigDir);
+  await fs.writeFile(this.configPath, docString);
+  
+  // Small delay to ensure file is written
+  await new Promise(resolve => setTimeout(resolve, 100));
+});
+
+// Generic step for checking config contains text
+Then('the config should contain {string}', async function (expectedText) {
+  await new Promise(resolve => setTimeout(resolve, 100));
+  
+  const configExists = await fs.pathExists(this.configPath);
+  expect(configExists, `Config file should exist at ${this.configPath}`).to.be.true;
+  
+  const configContent = await fs.readFile(this.configPath, 'utf8');
+  expect(configContent, `Config should contain "${expectedText}"\nActual config:\n${configContent}`).to.include(expectedText);
+});
+
+// Exit status checks - duplicates removed (defined in other step files)
+
 // Token storage step removed - JWT tokens are obtained via 'rfh auth login'
 
 Then('{string} should be the current active registry', async function (name) {


### PR DESCRIPTION
Add registry type support to distinguish between remote-http and git registries:
- Add RegistryType enum with remote-http (default) and git types
- Extend Registry struct with Type and GitToken fields
- Update CLI commands to support --type flag with validation
- Add automatic migration for existing configs without type field
- Implement comprehensive Cucumber test coverage for new functionality
- Fix test isolation issue in auth step definitions

Key changes:
- internal/config/cli.go: Add type definitions, migration logic, validation helpers
- internal/cli/registry.go: Update add/list commands with type support and validation
- cucumber-testing/: Add 10 new test scenarios covering registry types and backward compatibility
- cucumber-testing/features/step_definitions/auth_steps.js: Fix config cleanup for reliable test isolation

All existing functionality preserved while enabling future git registry implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)